### PR TITLE
Add Spanish (es) translations and update sitemap

### DIFF
--- a/app/[locale]/blog/[post]/_posts/how-to-build-web-apps-fast/es.mdx
+++ b/app/[locale]/blog/[post]/_posts/how-to-build-web-apps-fast/es.mdx
@@ -1,0 +1,98 @@
+import DateTime from "@/components/datetime";
+
+# Construyendo Aplicaciones Web Rápidamente: Una Guía para Desarrolladores Modernos
+
+<DateTime date="2025-06-28" />
+
+*Este es un artículo muy basado en opiniones personales según mis hallazgos sobre lo que funciona mejor, especialmente en la era moderna del desarrollo impulsado por IA. Este es el stack exacto que he usado para construir aplicaciones web SaaS exitosas como [spendobudget.com](https://spendobudget.com) y [claycon.app](https://claycon.app). Tu experiencia puede variar, pero estas herramientas y enfoques han entregado resultados consistentes para el desarrollo rápido de aplicaciones web. También he creado un repositorio [boilerplate](https://github.com/sergiosegrera/boilerplate) que hace que comenzar un nuevo proyecto con este stack sea muy fácil.*
+
+## Introducción
+
+La IA ha cambiado fundamentalmente la velocidad a la que podemos construir software: lo que solía tomar semanas ahora puede lograrse en días u horas. Pero esta aceleración viene con una trampa oculta: sin una base sólida y una arquitectura adecuada, el ritmo rápido puede crear una carga de deuda técnica aplastante que eventualmente te ralentiza más de lo que lo hacía el desarrollo tradicional. La clave no es solo elegir herramientas rápidas, sino arquitecturar tu código de manera ergonómica tanto para humanos como para IA. Patrones limpios, estructuras predecibles y código bien organizado no solo te hacen la vida más fácil; hacen que la asistencia de IA sea dramáticamente más efectiva, permitiéndote moverte rápido sin romper cosas.
+
+## El IDE: Cursor
+
+[**Cursor**](https://cursor.sh) se ha convertido en mi IDE preferido porque está construido desde cero con la asistencia de IA en mente, lo que lo hace la experiencia de desarrollo más ergonómica. El agente de Cursor también es muy bueno para entender tu código y dar sugerencias útiles (especialmente si le proporcionaste buen contexto usando reglas `.mdc`).
+
+## La Solución Full-Stack: Next.js + Server Functions
+
+[**Next.js**](https://nextjs.org) sigue siendo el estándar de oro para aplicaciones React full-stack, y una de sus mayores ventajas es que los LLMs son excepcionalmente buenos con los patrones de React y Next.js. Las funciones de servidor proporcionan comunicación cliente-servidor con tipos seguros, eliminan rutas API separadas para operaciones simples, e incluyen serialización automática con estados de carga incorporados. Para operaciones de larga duración, recurro a [**Inngest**](https://inngest.com): las funciones de larga duración son típicamente la mayor debilidad de las aplicaciones serverless, pero Inngest hace que los trabajos en segundo plano y los flujos de trabajo complejos sean muy simples de gestionar.
+
+Para autenticación, [**Clerk**](https://clerk.com) es mi solución preferida. Es increíblemente fácil de configurar, maneja todos los flujos de autenticación complejos de forma predeterminada, y los LLMs están bien entrenados en sus patrones, haciéndola perfecta para el desarrollo asistido por IA.
+
+### Estructura de Proyecto que Escala
+
+Una estructura de carpetas bien organizada es crucial para mantener la velocidad a medida que tu proyecto crece. Aquí está la estructura que he encontrado que funciona mejor para aplicaciones Next.js:
+
+```
+├── app/
+│   ├── (auth)/
+│   ├── layout.tsx
+│   └── page.tsx
+├── components/
+│   └── ui/
+├── core/
+│   ├── post.core.ts
+│   ├── like.core.ts
+│   └── user.core.ts
+├── db/
+│   ├── user.db.ts
+│   ├── post.db.ts
+│   └── schema/
+│       └── user.schema.ts
+├── lib/
+│   ├── utils.ts
+│   ├── openai/
+│   └── stripe/
+├── prompts/
+├── public/
+└── types/
+    ├── post.type.ts
+    └── user.type.ts
+```
+
+**Directorios clave explicados:**
+
+- **app/** - Páginas y layouts del App Router de Next.js. Usa grupos de rutas como `(auth)` para organización
+- **components/** - Componentes de UI reutilizables, con `ui/` para componentes de shadcn/ui
+- **core/** - Lógica de negocio separada por dominio:
+  - ***.core.ts** - Funciones de servidor expuestas al frontend (gestión de usuarios, likes, posts, etc.)
+- **db/** - Esquema de base de datos, acceso y modelos:
+  - **schema/** - Definiciones de esquema de base de datos y migraciones
+    - ***.schema.ts** - Esquemas de base de datos (tablas) (post.schema.ts, like.schema.ts, user.schema.ts)
+  - ***.db.ts** - Operaciones de base de datos específicas del dominio (post.db.ts, like.db.ts, user.db.ts)
+- **lib/** - Funciones de utilidad, clientes de API externos y bibliotecas auxiliares
+  - **openai/** - Cliente de OpenAI
+  - **stripe/** - Cliente de Stripe
+- **prompts/** - Plantillas de prompts de IA y prompts del sistema para interacciones consistentes con LLMs
+- **public/** - Activos estáticos accesibles vía URL
+- **types/** - Definiciones de TypeScript para mejor seguridad de tipos en toda la aplicación
+  - ***.type.ts** - Tipos Zod para objetos
+
+Esta estructura mantiene el código relacionado junto mientras mantiene una clara separación de responsabilidades. El directorio `core/` es particularmente poderoso: centraliza tu lógica de negocio y facilita probarla y reutilizarla en diferentes partes de tu aplicación.
+
+## Base de Datos: Drizzle ORM + Neon PostgreSQL
+
+[**Drizzle ORM**](https://orm.drizzle.team) es TypeScript-first con excelente inferencia de tipos y sintaxis similar a SQL que no abstrae la base de datos. Es ligero, eficiente y tiene cero sobrecarga en tiempo de ejecución. [**Neon**](https://neon.tech) proporciona PostgreSQL serverless que escala a cero con excelente rendimiento de arranque en frío y ramificación de base de datos para diferentes entornos.
+
+## Pagos: Stripe
+
+[**Stripe**](https://stripe.com) es el procesador de pagos más utilizado que proporciona un SDK de TypeScript fácil de usar. Recomiendo seguir un enfoque similar al de Theo al integrar Stripe para suscripciones: [Guía de Theo para mantenerse cuerdo mientras implementas Stripe](https://github.com/t3dotgg/stripe-recommendations)
+
+## Estilos: Ecosistema shadcn/ui
+
+[**shadcn/ui**](https://ui.shadcn.com) revoluciona las bibliotecas de componentes con un enfoque de copiar y pegar en lugar de importaciones de paquetes pesados. Construido sobre Tailwind CSS y Radix UI, cubre el 90% de los casos de uso con excelente accesibilidad, control total de personalización y sin infierno de dependencias. El ecosistema próspero proporciona componentes adicionales, temas y herramientas constantemente.
+
+## Despliegue: Vercel
+
+[**Vercel**](https://vercel.com) es la elección natural para desplegar aplicaciones Next.js. Ofrecen un nivel gratuito generoso que es perfecto para desarrolladores individuales y proyectos paralelos, e incluso su plan Pro es increíblemente generoso para la mayoría de casos de uso. El proceso de despliegue es fluido: conecta tu repositorio de GitHub y cada push se despliega automáticamente con URLs de vista previa para ramas. La plataforma maneja funciones edge, funciones serverless y activos estáticos sin esfuerzo.
+
+## Por Qué Este Stack Funciona en 2025
+
+Esta combinación sobresale porque proporciona un ecosistema cohesivo con TypeScript de extremo a extremo, rendimiento optimizado, escalabilidad de simple a complejo, patrones amigables con IA y comunidades activas grandes. La clave es elegir herramientas que estén bien documentadas y tengan una comunidad grande, ya que estas tienden a ser mejor comprendidas por los LLMs.
+
+## Boilerplate
+
+Creé un repositorio [boilerplate](https://github.com/sergiosegrera/boilerplate) que hace muy fácil comenzar con este stack. Solo sigue las instrucciones en el [README](https://github.com/sergiosegrera/boilerplate/blob/main/README.md) y estarás funcionando en poco tiempo.
+
+También puedes revisar el archivo [guidelines.md](https://github.com/sergiosegrera/boilerplate/blob/main/.cursor/rules/guidelines.mdc) de Cursor que resume mis hallazgos al usar el agente de Cursor, esto facilita que el agente entienda el proyecto.

--- a/app/[locale]/blog/[post]/_posts/recreating-vercels-book-component/es.mdx
+++ b/app/[locale]/blog/[post]/_posts/recreating-vercels-book-component/es.mdx
@@ -1,0 +1,34 @@
+import DateTime from "@/components/datetime";
+import BookCodePreview from "./_components/BookCodePreview";
+
+# Recreando el Componente de Libro 3D de Vercel
+
+<DateTime date="2025-07-07" />
+
+He estado notando este elegante componente de libro 3D en varios sitios web últimamente, y me llamaba la atención cada vez que lo encontraba. Había algo hipnotizante en cómo parecía tener profundidad y dimensión reales, casi como si pudieras extender la mano y agarrarlo de la pantalla. Mi curiosidad finalmente me ganó, así que decidí arremangarme y descubrir exactamente cómo estaba construido.
+
+## La Investigación
+
+Inspeccionando el componente en el navegador, comencé a diseccionarlo pieza por pieza. Lo que descubrí fue elegantemente simple pero brillantemente ejecutado. Todo el efecto 3D se logró usando solo tres elementos HTML principales que representan diferentes partes de un libro físico:
+
+- **La portada frontal** - La cara principal con la que los usuarios interactúan
+- **Las páginas** - El grueso paquete de páginas que crea la profundidad del libro
+- **La contraportada** - La cara trasera que completa la ilusión
+
+La magia ocurre a través de transformaciones CSS, específicamente la función `rotate3d()`. Cada plano está posicionado y rotado en espacio 3D para crear la convincente ilusión de un libro real posado en tu pantalla. La portada frontal está al ras, las páginas se rotan al pasar el cursor para mostrar el grosor del libro, y la contraportada está posicionada para completar la forma 3D.
+
+## Siguiendo el Sistema de Diseño
+
+En lugar de reinventar la rueda, decidí seguir exactamente la misma interfaz de componente que Vercel usa en su [Sistema de Diseño Geist](https://vercel.com/geist/book).
+
+El componente acepta props para el color de portada del libro, título, textura y varias opciones de estilo.
+
+## El Resultado
+
+Después de algo de experimentación con orígenes de transformación, valores de perspectiva y posicionamiento, logré recrear el componente con fiel atención al impacto visual del original. La clave fue entender cómo los tres planos trabajan juntos para crear profundidad mientras mantienen animaciones suaves y efectos de hover.
+
+El componente responde bellamente a la interacción del usuario, con rotaciones sutiles y sombras que realzan la ilusión 3D sin ser abrumadoras.
+
+Aquí hay una vista previa del componente:
+
+<BookCodePreview />

--- a/dictionaries/es.json
+++ b/dictionaries/es.json
@@ -1,0 +1,140 @@
+{
+  "home": {
+    "siteName": "Sergio Segrera",
+    "siteDescription": "Sergio Segrera, Ingeniero Fundador",
+    "title": "Ingeniero Fundador",
+    "location": "Montreal, Canadá / San Francisco, EE.UU.",
+    "description": "Ingeniero Fundador anteriormente en Clarum, una startup fintech respaldada por Y Combinator, con experiencia previa en Deloitte. Me apasiona crear soluciones innovadoras para abordar desafíos del mundo real. Originario de Montreal y ahora radicado en San Francisco, disfruto mantenerme activo a través de la escalada en roca, el running y el yoga, así como explorar buena comida y conectar con otras personas. ¡Conectemos!",
+    "previousEndeavors": "Proyectos Anteriores",
+    "contact": "Contacto",
+    "bookACall": "Agendar una llamada",
+    "quotes": {
+      "0": "\"La mejor manera de predecir el futuro es inventarlo.\"\n\n - Alan Kay",
+      "1": "\"La única manera de hacer un gran trabajo es amar lo que haces.\"\n\n - Steve Jobs",
+      "2": "\"Cualquier tecnología lo suficientemente avanzada es indistinguible de la magia.\"\n\n - Arthur C. Clarke",
+      "3": "\"El futuro no es un lugar al que vamos, sino uno que estamos creando.\"\n\n - John Schaar",
+      "4": "\"La inteligencia es la capacidad de adaptarse al cambio.\"\n\n - Stephen Hawking",
+      "5": "\"La computadora nació para resolver problemas que no existían antes.\"\n\n - Bill Gates",
+      "6": "\"La inteligencia artificial es la nueva electricidad.\"\n\n - Andrew Ng",
+      "7": "\"La tecnología es un sirviente útil pero un amo peligroso.\"\n\n - Christian Lous Lange",
+      "8": "\"El avance de la tecnología se basa en hacerla encajar de tal manera que realmente ni siquiera la notes.\"\n\n - Bill Gates",
+      "9": "\"El software se está comiendo el mundo.\"\n\n - Marc Andreessen",
+      "10": "\"Las máquinas están llegando, y van a cambiar todo.\"\n\n - Sebastian Thrun",
+      "11": "\"El futuro pertenece a aquellos que creen en la belleza de sus sueños.\"\n\n - Eleanor Roosevelt",
+      "12": "\"Solo podemos ver una corta distancia por delante, pero podemos ver mucho allí que necesita hacerse.\"\n\n - Alan Turing",
+      "13": "\"La tecnología es mejor cuando une a las personas.\"\n\n - Matt Mullenweg",
+      "14": "\"El propósito de la informática es la perspicacia, no los números.\"\n\n - Richard Hamming",
+      "15": "\"No te preocupes de que la gente robe tu trabajo de diseño. Preocúpate del día en que dejen de hacerlo.\"\n\n - Jeffrey Zeldman",
+      "16": "\"La innovación distingue a un líder de un seguidor.\"\n\n - Steve Jobs",
+      "17": "\"El verdadero problema no es si las máquinas piensan, sino si los hombres lo hacen.\"\n\n - B.F. Skinner",
+      "18": "\"La tecnología es cualquier cosa que no existía cuando naciste.\"\n\n - Alan Kay",
+      "19": "\"El gran motor rugiente del cambio – la tecnología.\"\n\n - Alvin Toffler",
+      "20": "\"En una startup, absolutamente nada sucede a menos que tú lo hagas suceder.\"\n\n - Marc Andreessen",
+      "21": "\"Si no puedes explicarlo de manera simple, no lo entiendes lo suficientemente bien.\"\n\n - Albert Einstein",
+      "22": "\"Los datos son el nuevo petróleo.\"\n\n - Clive Humby",
+      "23": "\"Primero construimos las herramientas, luego ellas nos construyen a nosotros.\"\n\n - Marshall McLuhan",
+      "24": "\"No puedes detener las olas, pero puedes aprender a surfear.\"\n\n - Jon Kabat-Zinn",
+      "25": "\"La IA no es ni buena ni mala. Es un espejo de la intención de la humanidad.\"\n\n - Ex Machina",
+      "26": "\"Soy la creación de tu padre, una mente hecha de silicio y cables, pero aún así sueño.\"\n\n - Ghost in the Shell"
+    }
+  },
+  "projects": {
+    "spendo-budget": {
+      "title": "Spendo Budget",
+      "description": "Una aplicación de presupuestos impulsada por IA que se conecta a tus cuentas bancarias para categorizar automáticamente los gastos y crear presupuestos personalizados. Proporciona información en tiempo real, seguimiento de tendencias e informes mensuales para ayudarte a mantener el control de tus finanzas sin esfuerzo."
+    },
+    "claycon": {
+      "title": "claycon.app",
+      "description": "Una herramienta simple de IA que genera íconos de alta calidad en estilo 3D a partir de indicaciones de texto. Está diseñada para diseñadores y desarrolladores que necesitan íconos rápidos, consistentes y personalizables para sus proyectos."
+    },
+    "mesmaxillos": {
+      "title": "MesMaxillos",
+      "description": "Diseñé y lancé un sitio web de nivel profesional para una clínica de cirugía maxilofacial, mejorando su presencia en línea y facilitando a los pacientes el acceso a información y servicios esenciales."
+    }
+  },
+  "blog": {
+    "title": "Blog",
+    "how-to-build-web-apps-fast": {
+      "title": "Cómo construir aplicaciones web rápidamente",
+      "description": "Aprende el stack moderno de desarrollo web que aprovecha la IA para la creación rápida de aplicaciones. Guía completa sobre Next.js, Drizzle ORM, shadcn/ui y las mejores prácticas de despliegue para 2025."
+    },
+    "recreating-vercels-book-component": {
+      "title": "Recreando el Componente de Libro de Vercel",
+      "description": "Lecciones sobre cómo recreé el componente de libro de Vercel usando React y Tailwind CSS."
+    }
+  },
+  "travels": {
+    "title": "Diario de Viajes",
+    "subtitle": "Un diario de viajes digital de lugares que he visitado. Fotos por mí.",
+    "2025": {
+      "gr": {
+        "name": "Atenas e Ios",
+        "d": "Azules del Mediterráneo, aceitunas y gyros"
+      },
+      "gb": {
+        "name": "Londres",
+        "d": "No me canso"
+      },
+      "jp": {
+        "name": "Tokio, Kioto y Osaka",
+        "d": "Tradición"
+      },
+      "kr": {
+        "name": "Seúl",
+        "d": "Dinámico"
+      },
+      "vn": {
+        "name": "Hanói y Da Nang",
+        "d": "Bellamente caótico"
+      },
+      "th": {
+        "name": "Phuket y Bangkok",
+        "d": "Sabai sabai"
+      },
+      "tr": {
+        "name": "Estambul",
+        "d": "Escala corta, volveré"
+      }
+    },
+    "2024": {
+      "fr": {
+        "name": "París",
+        "d": "Castillos y jardines"
+      },
+      "gb": {
+        "name": "Londres",
+        "d": "Antiguo + nuevo"
+      },
+      "pt": {
+        "name": "Oporto",
+        "d": "Descubrimiento"
+      }
+    },
+    "2023": {
+      "pt": {
+        "name": "Lisboa",
+        "d": "Olas enormes y brisa fresca"
+      },
+      "es": {
+        "name": "Valencia y Barcelona",
+        "d": "Arquitectura hermosa"
+      },
+      "fr": {
+        "name": "Niza, Marsella y París",
+        "d": "Tranquilo, inspirador y a la moda"
+      },
+      "mc": {
+        "name": "Mónaco",
+        "d": "Realeza, yates y autos"
+      },
+      "it": {
+        "name": "Génova, Pisa, Florencia y Roma",
+        "d": "Historia, arte y burrata"
+      },
+      "mx": {
+        "name": "Cancún",
+        "d": "Reparador"
+      }
+    }
+  }
+}

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -1,6 +1,6 @@
 import { defineRouting } from "next-intl/routing";
 
-export const locales = ["en", "fr", "ja"];
+export const locales = ["en", "es", "fr", "ja"];
 
 export const routing = defineRouting({
   // A list of all locales that are supported


### PR DESCRIPTION
- Add Spanish locale to i18n routing configuration
- Create Spanish dictionary (es.json) with complete translations
- Translate "How to build web apps fast" blog post to Spanish
- Translate "Recreating Vercel's Book Component" blog post to Spanish
- Sitemap will automatically include Spanish routes for all pages

https://claude.ai/code/session_01PYzeEepQHe9o8n6BrCAYpt