### PR TITLE
Fix typo in English travel log subtitle

### DIFF
--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -65,7 +65,7 @@
   },
   "travels": {
     "title": "Travel Log",
-    "subtitle": "A digital travel log of places I have visited. Pictures my me.",
+    "subtitle": "A digital travel log of places I have visited. Pictures by me.",
     "2025": {
       "gr": {
         "name": "Athens & Ios",


### PR DESCRIPTION
The subtitle for the travel log section had a typo in the English dictionary. This change fixes "Pictures my me" to "Pictures by me" to correctly attribute the photos. Visual verification was performed to ensure the correct text appears on the frontend.

---
*PR created automatically by Jules for task [12429829537625622458](https://jules.google.com/task/12429829537625622458) started by @sergiosegrera*